### PR TITLE
fix: add use/custom-template jobs

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -14,3 +14,14 @@ jobs:
         <<: *publish
         environment:
             SD_TEMPLATE_PATH: ./sd-invalid-template.yaml
+    use-template:
+        template: screwdriver-cd-test/test-template@1.0.0
+    custom-template:
+        image: node:12
+        template: screwdriver-cd-test/test-template@1.0.0
+        steps:
+            - preinstall: echo 'preinstall'
+            - postinstall: echo 'postinstall'
+            - pretest: echo 'pretest'
+            - test: echo 'override'
+            - posttest: echo 'posttest'


### PR DESCRIPTION
## Context

To make preparing template functional tests added by this [PR](https://github.com/screwdriver-cd/screwdriver/pull/2593) easier.

## Objective

I will move `use-template` and `custom-template` jobs from `master` branch to `wrong-permission` branch.

After merge these following PRs, please rename `wrong-permission` branch to `second` and change the pipeline's branch.
- this PR 
- https://github.com/screwdriver-cd-test/functional-template/pull/1

## References
- https://github.com/screwdriver-cd/screwdriver/pull/2597
